### PR TITLE
Fix date-bug for Safari browser

### DIFF
--- a/public/assets/NL_kaart/NL_map_content.php
+++ b/public/assets/NL_kaart/NL_map_content.php
@@ -2,6 +2,7 @@
 <link rel="stylesheet" href="/assets/NL_kaart/rangeStyle.css">
 <script type="text/javascript" src="/assets/NL_kaart/NL_map_loadContent.js"></script>
 <script type="text/javascript" src="/assets/NL_kaart/NL_map_legend.js"></script>
+<script type="text/javascript" src="/assets/getDateString.js"></script>
 
 <div id="errorAlert"></div>
 

--- a/public/assets/NL_kaart/NL_map_loadContent.js
+++ b/public/assets/NL_kaart/NL_map_loadContent.js
@@ -54,9 +54,9 @@ function covid19Reports_Process(dataSet) {
 	
 	//Place slider label above the holder (at the end).
 	rangeV.style.setProperty("left", "calc(100% + -10px)")
+	
 	//Convert the selected date to "dd month"
-	const month = newestMapDate.toLocaleString('default', { month: 'long' });
-	var dateString = newestMapDate.getDate().toString() + ' ' + month
+	var dateString = getDayAndMonth(newestMapDate)
 	rangeV.innerHTML = '<span id="current-date">' + dateString + '</span>';
 	
 	//Change slide to last day

--- a/public/assets/NL_kaart/NL_map_loadContent.js
+++ b/public/assets/NL_kaart/NL_map_loadContent.js
@@ -7,7 +7,7 @@ var lastSelectedCity = null;
 //Datasets
 var request_covid19Reports = {
 	data: null,
-	startDate: "2020-02-27T03:00:00+0000",
+	startDate: "2020-02-27T03:00:00.000Z",
 	url: "/assets/NL_kaart/covid19_reports_every_day.json",
 	errorMessage: "Het laden van het aantal covid-19 meldingen is mislukt. Probeer het later nog eens."
 };
@@ -20,7 +20,7 @@ var request_populationPerCity = {
 
 var request_hospitalizationPerCity = {
 	data: null,
-	startDate: "2020-03-31T03:00:00+0000",
+	startDate: "2020-03-31T03:00:00.000Z",
 	url: "/assets/NL_kaart/covid19_hospitalizations.json",
 	errorMessage: "Het laden van aantal ziekenhuisopnamens per gemeente is mislukt. Probeer het later nog eens."
 };
@@ -36,13 +36,13 @@ function covid19Reports_Process(dataSet) {
 	
 	//TODO: This value should not be hardcoded
 	var amountOfDays = 48
-	if (dataSet.startDate == "2020-03-31T03:00:00+0000") amountOfDays = 15;
+	if (dataSet.startDate == "2020-03-31T03:00:00.000Z") amountOfDays = 15;
 	
 	selectedDataset = dataSet;
 	
 	//Determine last day
 	//var newestMapDate = new Date(dataSet.startDate);
-	var newestMapDate = new Date("2020-02-27T05:00:00.000Z");
+	var newestMapDate = new Date("2020-02-27T03:00:00.000Z");
 	newestMapDate.setDate(newestMapDate.getDate() + amountOfDays - 1);
 	
 	//Update the map

--- a/public/assets/getDateString.js
+++ b/public/assets/getDateString.js
@@ -1,0 +1,26 @@
+//This file is used for getting the date as a string.
+//This hardcoded method is needed because Safari does not know how to work with Date.toLocaleString('default', { month: 'long' });
+
+//Get name of month in Dutch from month number.
+function getMonthName(date) {
+  var month = new Array();
+  month[0] = "januari";
+  month[1] = "februari";
+  month[2] = "maart";
+  month[3] = "april";
+  month[4] = "mei";
+  month[5] = "juni";
+  month[6] = "juli";
+  month[7] = "augustus";
+  month[8] = "september";
+  month[9] = "october";
+  month[10] = "november";
+  month[11] = "december";
+
+  return month[date.getMonth()];
+}
+
+//Returns date as "dd month"
+function getDayAndMonth(date) {
+	return date.getDate() + " " + getMonthName(date);
+}


### PR DESCRIPTION
iOS devices with at least iOS 13 can use the slider now in the Safari web browser. It does not work for iOS 9. I don't know about the version in between.

Also, all 